### PR TITLE
remove locked colors from randomization

### DIFF
--- a/Palette.js
+++ b/Palette.js
@@ -3,10 +3,19 @@ class Palette {
     this.id = Date.now();
     this.colors = [];
   };
+
   newColorInstance(colorCount) {
     for (var i = 0; i < colorCount; i++) {
       var newColor = new Color();
-      this.colors.push(newColor);
+      if (this.colors.length < 5) {
+        this.colors.push(newColor);
+      };
     };
   };
+
+  shuffleColorInstance(){
+    var newColor = new Color();
+    return newColor
+  };
+
 };

--- a/scripts.js
+++ b/scripts.js
@@ -20,18 +20,14 @@ function paletteGenerator() {
 };
 
 function displayNewPalette(){
-  if(palette.colors.length !== 0) {
-    palette.colors = [];
+  shuffleColor()
+  paletteGenerator();
+    for(var i = 0; i < palette.colors.length; i++) {
+      colorBoxes[i].style.background = palette.colors[i].hexCode;
+      hexCodes[i].innerText = palette.colors[i].hexCode;
+      lockAndUnlockIcon[i].id = palette.colors[i].hexCode;
+    }; 
   };
-paletteGenerator();
-  for(var i = 0; i < palette.colors.length; i++) {
-    colorBoxes[i].style.background = palette.colors[i].hexCode;
-    hexCodes[i].innerText = palette.colors[i].hexCode;
-    lockAndUnlockIcon[i].id = palette.colors[i].hexCode;
-  }; console.log(palette);
-};
-
-
 
 function lockColor(e){
   for (let i = 0; i < palette.colors.length; i++) {
@@ -45,3 +41,12 @@ function lockColor(e){
     };
   };
 };
+
+function shuffleColor(){
+  for (let i = 0; i < palette.colors.length; i++) {
+    if (!palette.colors[i].locked) {
+      var shuffleColor = palette.shuffleColorInstance()
+      palette.colors.splice(i, 1, shuffleColor)
+    }   
+  }
+}


### PR DESCRIPTION
# iteration 1 complete.


**Group Paired Programming**

**describe high level changes being made**

1. remove locked icons from being able to be shuffled.
2. re-shuffle no-locked colors in palette
3.


*have you remembered to type a short, meaningful commit message that describes the change?*